### PR TITLE
Add support for invokable controllers and catch non-existing routes

### DIFF
--- a/src/Parser/WithAnnotationReader.php
+++ b/src/Parser/WithAnnotationReader.php
@@ -30,7 +30,11 @@ trait WithAnnotationReader
      */
     protected function routeAnnotation(Route $route, string $name = \OA\Tag::class): ?BaseAnnotation
     {
-        $annotations = $this->routeAnnotations($route, $name);
+        try {
+            $annotations = $this->routeAnnotations($route, $name);
+        } catch (\ReflectionException $e) {
+            return null;
+        }
 
         return ! empty($annotations) ? reset($annotations) : null;
     }
@@ -44,7 +48,11 @@ trait WithAnnotationReader
      */
     protected function routeAnnotations(Route $route, ?string $name = null) :array
     {
-        $ref = $this->routeReflection($route);
+        try {
+            $ref = $this->routeReflection($route);
+        } catch (\ReflectionException $e) {
+            return [];
+        }
         if (! $ref instanceof \ReflectionMethod) {
             return [];
         }
@@ -74,7 +82,11 @@ trait WithAnnotationReader
      */
     protected function controllerAnnotations(Route $route, ?string $name = null, bool $checkExtending = false, bool $mergeExtended = false): array
     {
-        $ref = $this->routeReflection($route);
+        try {
+            $ref = $this->routeReflection($route);
+        } catch (\ReflectionException $e) {
+            return [];
+        }
         if (! $ref instanceof \ReflectionMethod) {
             return [];
         }

--- a/src/Parser/WithRouteReflections.php
+++ b/src/Parser/WithRouteReflections.php
@@ -27,6 +27,10 @@ trait WithRouteReflections
         $controller = $route->getController();
         $method = $route->getActionMethod();
 
+        if ($method === get_class($controller)) {
+            return $this->reflectionClass($controller)->getMethod('__invoke');
+        }
+
         return $this->reflectionMethod($controller, $method);
     }
 }


### PR DESCRIPTION
Add support for invokable controller routes.
Discoved an error when trying to generate docs while having Spatie/Laravel-Ignition enabled:

```
   ReflectionException 

  Method Spatie\LaravelIgnition\Http\Controllers\HealthCheckController::Spatie\LaravelIgnition\Http\Controllers\HealthCheckController() does not exist

  at vendor/digit-soft/laravel-swagger-generator/src/Parser/WithReflections.php:27
     23▕     {
     24▕         $refClass = $this->reflectionClass($class);
     25▕         $methodName = $refClass->name . '::' . $method;
     26▕         if (! isset($this->reflections[$methodName])) {
  ➜  27▕             $this->reflections[$methodName] = $refClass->getMethod($method);
     28▕         }
     29▕ 
     30▕         return $this->reflections[$methodName];
     31▕     }
```